### PR TITLE
fix(parser): fix bug: install command error when module is empty

### DIFF
--- a/install/parser/loader_test.go
+++ b/install/parser/loader_test.go
@@ -1,0 +1,50 @@
+package parser
+
+import "testing"
+
+func Test_defaultPackageName(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				dir: "../../",
+			},
+			want: "base",
+		},
+		{
+			name: "test",
+			args: args{
+				dir: "www/xxx/111",
+			},
+			want: "base",
+		},
+		{
+			name: "test",
+			args: args{
+				dir: "www/xxx/111AAB",
+			},
+			want: "aab",
+		},
+		{
+			name: "test",
+			args: args{
+				dir: "www/xxx/111AA--B-xxx",
+			},
+			want: "aabxxx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultPackageName(tt.args.dir); got != tt.want {
+				t.Errorf("defaultPackageName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Implement defaultPackageName function to generate package names based on directory paths
- Update LoaderParser to use the new defaultPackageName function when package name is empty
- Add unit tests for defaultPackageName to ensure correct behavior